### PR TITLE
fix: Improve translation visibility in dark mode

### DIFF
--- a/js/connections.js
+++ b/js/connections.js
@@ -979,7 +979,7 @@ function showConnEncouragementModal(resultData, won, correctCount, mistakesUsed)
     verseEl.style.display = 'block';
     verseEl.innerHTML = `<span class="translation conn-explore-tap" style="cursor:pointer;">
         <span style="font-size:1.1rem;font-style:normal;">📖 Review the ayahs to earn more points!</span><br>
-        <span style="font-size:0.85rem;color:var(--text-secondary);">🌒 1pt = solved &nbsp; 🌙 2pts = solved + all verses reviewed &nbsp; 🌑 = missed</span><br>
+        <span style="font-size:0.85rem;color:var(--text);">🌒 1pt = solved &nbsp; 🌙 2pts = solved + all verses reviewed &nbsp; 🌑 = missed</span><br>
         <span style="font-size:0.9rem;margin-top:8px;display:inline-block;">Tap to start reviewing ▼</span>
     </span>`;
     verseEl.querySelector('.conn-explore-tap').addEventListener('click', () => {

--- a/style.css
+++ b/style.css
@@ -2165,7 +2165,7 @@ textarea {
     font-family: var(--font-main);
     font-size: 0.85rem;
     direction: ltr;
-    color: var(--text-secondary);
+    color: var(--text);
     margin-top: 8px;
     line-height: 1.5;
     font-style: italic;


### PR DESCRIPTION
## Summary

Fixes issue #71: "In dark mode the translation is not easy to see"

## Changes

- Changed `var(--text-secondary)` to `var(--text)` in `style.css` line 2168
- Changed `var(--text-secondary)` to `var(--text)` in `js/connections.js` line 982

## Why this fixes the issue

In dark mode, `--text-secondary` has lower contrast compared to `--text`. By using the primary text color variable (`--text`) instead of the secondary one (`--text-secondary`), translation text now has sufficient contrast to be easily readable in dark mode.

## Testing

The fix has been applied to both the CSS stylesheet and JavaScript file where translation text is styled. This ensures consistent visibility across all UI components that display translation text.

Fixes sudosar/quraniq-source#71