### PR TITLE
Fix #190: Prevent text overflow and truncation in harf modal and wbw display at large font sizes

### DIFF
--- a/style.css
+++ b/style.css
@@ -187,7 +187,13 @@ html[data-font-size="2"] {
     font-size: 125%;
 }
 
-/* Extra Large (~20px) */
+/* Extra Large: keep wbw-en label and verse slide text from overflowing.
+   Caps the effective inline-scale factor using small-screen rem caps. */
+@media (max-width: 480px) {
+    html[data-font-size="2"] {
+        font-size: 118%;
+    }
+}
 
 /* Islamic geometric pattern background overlay */
 body::before {
@@ -756,6 +762,9 @@ textarea {
     align-items: center;
     gap: 4px;
     position: relative;
+    max-width: 100%;
+    min-width: 0;
+    overflow: hidden;
 }
 
 .verse-nav {
@@ -787,6 +796,8 @@ textarea {
     position: relative;
     overflow: visible;
     touch-action: pan-y;
+    min-width: 0;
+    max-width: 100%;
 }
 
 .verse-slide {
@@ -794,6 +805,10 @@ textarea {
     text-align: center;
     animation: verseFadeIn 0.3s ease;
     padding: 4px 8px;
+    max-width: 100%;
+    min-width: 0;
+    overflow: hidden;
+    box-sizing: border-box;
 }
 
 .verse-slide.active {
@@ -818,6 +833,8 @@ textarea {
     font-weight: 700;
     direction: rtl;
     margin-bottom: 2px;
+    overflow-wrap: anywhere;
+    max-width: 100%;
 }
 
 .verse-slide-meaning {
@@ -825,6 +842,8 @@ textarea {
     opacity: 0.75;
     margin-bottom: 8px;
     font-style: italic;
+    overflow-wrap: anywhere;
+    max-width: 100%;
 }
 
 .verse-slide-ayah {
@@ -837,6 +856,10 @@ textarea {
     background: rgba(255, 255, 255, 0.2);
     border-radius: 8px;
     padding: 12px 16px;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    max-width: 100%;
+    box-sizing: border-box;
 }
 
 .verse-slide-en {
@@ -850,6 +873,10 @@ textarea {
     margin-bottom: 12px;
     text-align: left;
     border-left: 3px solid var(--accent);
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    max-width: 100%;
+    box-sizing: border-box;
 }
 
 [data-theme="dark"] .verse-slide-en {
@@ -984,12 +1011,24 @@ textarea {
 .verse-card {
     margin-bottom: 4px;
     position: relative;
+    /* Contain child overflow at large font sizes; allow scrolling when the
+       word-by-word display grows beyond a sensible height. */
+    max-height: 60vh;
+    max-width: 100%;
+    width: 100%;
+    overflow-y: auto;
+    overflow-x: hidden;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+    box-sizing: border-box;
 }
 
 .wbw-container {
     position: relative;
     width: 100%;
+    max-width: 100%;
     box-sizing: border-box;
+    overflow-x: hidden;
 }
 
 .wbw-words {
@@ -1024,6 +1063,12 @@ textarea {
     -webkit-user-select: none;
     position: relative;
     -webkit-tap-highlight-color: rgba(27, 122, 74, 0.15);
+    /* Keep English label and Arabic word inside their container */
+    max-width: min(180px, 100%);
+    overflow: hidden;
+    box-sizing: border-box;
+    flex-shrink: 1;
+    min-width: 0;
 }
 
 .wbw-word.wbw-highlight {
@@ -1047,16 +1092,23 @@ textarea {
     background: #1b7a4a;
     padding: 2px 6px;
     border-radius: 4px;
-    white-space: nowrap;
-    max-width: 150px;
-    overflow: visible;
-    text-overflow: clip;
-    line-height: 1.6;
+    white-space: normal;
+    /* Allow wrapping and clipping instead of letting translation spill out at large font sizes */
+    max-width: 180px;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    line-height: 1.4;
     margin-bottom: 4px;
     animation: wbwEnFadeIn 0.2s ease;
     pointer-events: none;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
     text-align: center;
+    /* Cap width to the container so wbw-en never extends past the parent */
+    width: max-content;
+    max-width: min(180px, 100%);
+    box-sizing: border-box;
 }
 
 [data-theme="dark"] .wbw-en {
@@ -1152,6 +1204,87 @@ textarea {
     text-align: center;
     margin-top: 6px;
     pointer-events: none;
+}
+
+/* ===== Theme Verses (Connections) ===== */
+.connections-theme-verses {
+    display: none;
+    margin-top: 20px;
+    margin-bottom: 12px;
+    padding: 14px 12px 16px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    text-align: center;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.connections-theme-verses h3 {
+    font-size: 0.85rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-bottom: 12px;
+    opacity: 0.7;
+    color: var(--text);
+}
+
+.theme-verse-item {
+    border-radius: var(--radius-sm);
+    padding: 12px 14px;
+    margin-bottom: 10px;
+    word-wrap: break-word;
+    overflow-wrap: anywhere;
+    max-width: 100%;
+    overflow: hidden;
+    text-align: center;
+}
+
+.theme-verse-item:last-child {
+    margin-bottom: 0;
+}
+
+.theme-verse-cat {
+    font-weight: 700;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 4px;
+}
+
+.theme-verse-ar {
+    font-family: var(--font-arabic);
+    font-size: 1.15rem;
+    direction: rtl;
+    line-height: 1.8;
+    margin-bottom: 6px;
+    overflow-wrap: anywhere;
+}
+
+.theme-verse-en {
+    font-size: 0.85rem;
+    line-height: 1.5;
+    font-style: italic;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
+/* Coloured backgrounds per Connections group — reuse existing palette */
+.theme-verse-item.yellow {
+    background: var(--conn-yellow);
+    color: var(--conn-yellow-text);
+}
+.theme-verse-item.green {
+    background: var(--conn-green);
+    color: var(--conn-green-text);
+}
+.theme-verse-item.blue {
+    background: var(--conn-blue);
+    color: var(--conn-blue-text);
+}
+.theme-verse-item.purple {
+    background: var(--conn-purple);
+    color: var(--conn-purple-text);
 }
 
 /* Dots indicator */


### PR DESCRIPTION
## Bug

When users set extra-large font size (the largest setting in the Accessibility menu), word-by-word English translations got truncated mid-word and other text in the verse carousel overlapped its bounds.

## Root cause

1. `.wbw-en` (English label above each Arabic word) had `overflow: visible` and `white-space: nowrap` with a fixed `max-width: 150px` — the label could spill beyond its parent with no clipping.
2. `.verse-card` had no max-height or overflow handling, so when many wbw words were visible at once, the card expanded unbounded and pushed the bottom navbar off-screen.
3. The `.verse-carousel.expanded`, `.verse-slides`, `.verse-slides-container`, and `.verse-slide` containers had no max-width constraint, so an oversized wbw-word could blow the whole carousel past the viewport edge.
4. `.connections-theme-verses` (the post-game Theme Verses section) had **no CSS defined at all** — items rendered as default-flow blocks with no padding, colors, or overflow handling, so they overlapped controls and spilled beyond the viewport on small screens.

## Fix (style.css only)

- `.wbw-en`: switch to `white-space: normal` + `overflow-wrap: anywhere` + `overflow: hidden` + `max-width: min(180px, 100%)` so labels wrap inside their container and never spill.
- `.wbw-word`, `.wbw-container`, `.verse-card`, `.verse-slides-container`, `.verse-slides`, `.verse-slide`: add `max-width: 100%`, `min-width: 0`, and explicit width so flex children shrink properly.
- `.verse-card`: add `max-height: 60vh` + `overflow-y: auto` so a tall wbw display scrolls inside its box instead of overflowing the page.
- `.verse-slide-ayah`, `.verse-slide-en`, `.verse-slide-word`, `.verse-slide-meaning`: add `overflow-wrap: anywhere` + `max-width: 100%` so long Arabic or English lines break cleanly.
- `.connections-theme-verses`, `.theme-verse-item`, `.theme-verse-cat`, `.theme-verse-ar`, `.theme-verse-en`: add the missing CSS — proper card layout, Connections colour variants, and wrap-safe overflow handling.
- `html[data-font-size="2"]: Cap XL font at 118% on small screens (≤480px) so root scaling doesn't crowd mobile UI.

## Validation

Puppeteer tests on 390×844 viewport (mobile) verified:
- font sizes 0/1/2: no horizontal overflow (innerW === htmlScrollWidth === 390)
- stress test with extremely long English translation: label wraps within its word, no overflow past screen edge
- 18-word wbw display at XL font: `.verse-card` correctly scrolls (`scrollH=1305, clientH=506, overflowY=auto`)
- all game tabs (connections/harf/deduction/scramble/juz): no overflow at XL font

Visually verified via image-tool that labels stay inside their word-boxes, the Theme Verses section displays cleanly, and no English text is cut off mid-word anymore.

Closes #190